### PR TITLE
Add SetWindowCloseButton

### DIFF
--- a/HideWindowApp/src/Makefile
+++ b/HideWindowApp/src/Makefile
@@ -9,11 +9,13 @@ include $(TOP)/configure/CONFIG
 # build a support library
 
 PROD_HOST += HideWindow SetQuickEditMode RunWithGlobalLock RunHidden
+PROD_HOST += SetWindowCloseButton
 
 # specify all source files to be compiled and added to the library
 HideWindow_SRCS += hidewindow.cc
 SetQuickEditMode_SRCS += SetQuickEditMode.cc
 RunWithGlobalLock_SRCS += RunWithGlobalLock.cc
+SetWindowCloseButton_SRCS += SetWindowCloseButton.cc
 RunHidden_SRCS += runhidden.cc
 
 HideWindow_LIBS += $(EPICS_BASE_HOST_LIBS)
@@ -27,6 +29,9 @@ RunWithGlobalLock_SYS_LIBS_WIN32 += kernel32 user32
 
 RunHidden_LDFLAGS_WIN32 += -subsystem:windows
 RunHidden_SYS_LIBS_WIN32 += kernel32 user32
+
+SetWindowCloseButton_LIBS += $(EPICS_BASE_HOST_LIBS)
+SetWindowCloseButton_SYS_LIBS_WIN32 += kernel32 user32
 
 #===========================
 

--- a/HideWindowApp/src/SetWindowCloseButton.cc
+++ b/HideWindowApp/src/SetWindowCloseButton.cc
@@ -1,0 +1,28 @@
+#include <windows.h>
+#include <stdio.h>
+
+// usage: SetWindowCloseButton [enable|disable]
+int main(int argc, char* argv[])
+{
+	HWND conwin = GetConsoleWindow();
+	if ( (conwin != NULL) && (argc >= 2) )
+	{
+		    switch(argv[1][0])
+			{
+				case 'E': // enable
+				case 'e': 
+			        EnableMenuItem(GetSystemMenu(conwin, FALSE), SC_CLOSE, MF_BYCOMMAND | MF_ENABLED);
+					break;
+
+				case 'D': // disable
+				case 'd':
+					EnableMenuItem(GetSystemMenu(conwin, FALSE), SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+					break;
+
+				default:
+					printf("%s: Invalid argument \"%s\"\n", argv[0], argv[1]);
+					break;
+			}
+	}
+	return 0;
+}


### PR DESCRIPTION
Add exe that can be run to disable window close button e.g. if we are running a bat like start_ibex_server and don't want to be accidentally closed. You can still ctrl-C any command or type exit, just not close the console window by clicking on the X in the top right 

## to test

from an epics terminal run

`SetWindowCloseButton.exe d` and see close greyed out, run `SetWindowCloseButton.exe e` to re-enable

